### PR TITLE
Preliminary requirement for Scheduler changes

### DIFF
--- a/yakt.sh
+++ b/yakt.sh
@@ -169,6 +169,7 @@ log_info "Done."
 # Tweak scheduler to have less Latency
 # Credits to RedHat & tytydraco & KTweak
 log_info "Tweaking scheduler to reduce latency"
+write_value "$KERNEL_PATH/sched_tunable_scaling" 0
 write_value "$KERNEL_PATH/sched_migration_cost_ns" 50000
 write_value "$KERNEL_PATH/sched_min_granularity_ns" 1000000
 write_value "$KERNEL_PATH/sched_wakeup_granularity_ns" 1500000


### PR DESCRIPTION
most of the kernel uses linear by default ( value * ncpus ) set sched_tunable_scaling to unscaled  ( value * 1 )